### PR TITLE
Chore(kube_downscaler/main.py) Adding regex to match with "_"

### DIFF
--- a/kube_downscaler/main.py
+++ b/kube_downscaler/main.py
@@ -18,7 +18,7 @@ from pykube.objects import NamespacedAPIObject
 
 WEEKDAYS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']
 
-TIME_SPEC_PATTERN = re.compile(r'^([a-zA-Z]{3})-([a-zA-Z]{3}) (\d\d):(\d\d)-(\d\d):(\d\d) (?P<tz>[a-zA-Z\/_]+)$')
+TIME_SPEC_PATTERN = re.compile(r'^([a-zA-Z]{3})-([a-zA-Z]{3}) (\d\d):(\d\d)-(\d\d):(\d\d) (?P<tz>[a-zA-Z/_]+)$')
 
 ORIGINAL_REPLICAS_ANNOTATION = 'downscaler/original-replicas'
 

--- a/kube_downscaler/main.py
+++ b/kube_downscaler/main.py
@@ -18,7 +18,7 @@ from pykube.objects import NamespacedAPIObject
 
 WEEKDAYS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']
 
-TIME_SPEC_PATTERN = re.compile(r'^([a-zA-Z]{3})-([a-zA-Z]{3}) (\d\d):(\d\d)-(\d\d):(\d\d) (?P<tz>[a-zA-Z/]+)$')
+TIME_SPEC_PATTERN = re.compile(r'^([a-zA-Z]{3})-([a-zA-Z]{3}) (\d\d):(\d\d)-(\d\d):(\d\d) (?P<tz>[a-zA-Z\/_]+)$')
 
 ORIGINAL_REPLICAS_ANNOTATION = 'downscaler/original-replicas'
 


### PR DESCRIPTION
I need to add the timezone "America / Sao_Paulo". However, in the regex there is no "_", made the adjustment.

```
ValueError: Time spec value "Mon-Fri 07:30-20:30 America/Sao_Paulo" does not match format (Mon-Fri 06:30-20:30 Europe/Berlin)

```