### PR TITLE
Weekday should respect timezone

### DIFF
--- a/kube_downscaler/main.py
+++ b/kube_downscaler/main.py
@@ -56,11 +56,11 @@ def matches_time_spec(time: datetime.datetime, spec: str):
         if not match:
             raise ValueError(
                 f'Time spec value "{spec}" does not match format (Mon-Fri 06:30-20:30 Europe/Berlin)')
-        day_from = WEEKDAYS.index(match.group(1).upper())
-        day_to = WEEKDAYS.index(match.group(2).upper())
-        day_matches = day_from <= time.weekday() <= day_to
         tz = pytz.timezone(match.group('tz'))
         local_time = tz.fromutc(time.replace(tzinfo=tz))
+        day_from = WEEKDAYS.index(match.group(1).upper())
+        day_to = WEEKDAYS.index(match.group(2).upper())
+        day_matches = day_from <= local_time.weekday() <= day_to
         local_time_minutes = local_time.hour * 60 + local_time.minute
         minute_from = int(match.group(3)) * 60 + int(match.group(4))
         minute_to = int(match.group(5)) * 60 + int(match.group(6))

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -21,3 +21,7 @@ def test_time_spec():
     assert not matches_time_spec(dt, 'Mon-Fri 08:00-18:00 UTC')
 
     assert matches_time_spec(dt, 'Mon-Fri 08:00-18:00 UTC, Sun-Sun 15:30-16:00 UTC')
+
+    dt = datetime(2018, 11, 4, 20, 30, 00)
+    assert matches_time_spec(dt, 'Mon-Fri 09:00-10:00 Pacific/Auckland')
+    assert not matches_time_spec(dt, 'Sat-Sun 09:00-10:00 Pacific/Auckland')


### PR DESCRIPTION
Our default uptime is "Mon-Fri 06:30-19:30 Pacific/Auckland"
On Monday, the cluster doesn't scale up until 1pm

After digging around a bit I see this is because the code in `matches_time_spec` compares the weekday from the UTC time. Monday morning in New Zealand is still Sunday evening in UTC, so the cluster doesn't match the day until 1pm on Monday when UTC becomes Monday.

I think `matches_time_spec` should get the weekday from the local time.