### PR TITLE
Support for annotations on namespace level

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ It will scale the deployment's replicas to zero if all of the following conditio
 
 * current time is not part of the "uptime" schedule or current time is part of the "downtime" schedule. The schedules are being evaluated in following order: 
     * ``downscaler/downtime`` annotation on the deployment/stateful set
-    * ``downscaler/uptime`` annotation on the deployment/stateful sett
+    * ``downscaler/uptime`` annotation on the deployment/stateful set
     * ``downscaler/downtime`` annotation on the deployment/stateful set's namespace
     * ``downscaler/uptime`` annotation on th deployment/stateful set's namespace
     * ``--default-uptime`` cli argument

--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ Available command line options:
 Namespace Defaults
 ==================
 
-``DEFAULT_UPTIME``, ``DEFAULT_DOWNTIME`` and ``FORCE_UPTIME`` can also be configured using Namespace annotations. Where configured these values supersede the other global default values.
+``DEFAULT_UPTIME``, ``DEFAULT_DOWNTIME``, ``FORCE_UPTIME`` and exclusion can also be configured using Namespace annotations. Where configured these values supersede the other global default values.
 
 .. code-block:: yaml
 
@@ -117,7 +117,11 @@ Namespace Defaults
         annotations:
             downscaler/uptime: Mon-Sun 06:00-21:00 Europe/Berlin
 
-Following annotations are supported on the Namespace level: ``downscaler/uptime``, ``downscaler/downtime`` and ``downscaler/force-uptime``
+Following annotations are supported on the Namespace level: 
+* ``downscaler/uptime``
+* ``downscaler/downtime``
+* ``downscaler/force-uptime``
+* ``downscaler/exclude``
 
 Contributing
 ============

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,15 @@ Deployments are interchangeable by statefulset for this whole guide.
 
 It will scale the deployment's replicas to zero if all of the following conditions are met:
 
-* current time is not part of the "uptime" schedule (annotation ``downscaler/uptime``) or current time is part of the "downtime" schedule (``downscaler/downtime``)
+* current time is not part of the "uptime" schedule or current time is part of the "downtime" schedule. The schedules are being evaluated in following order: 
+    * ``downscaler/downtime`` annotation on the deployment/stateful set
+    * ``downscaler/uptime`` annotation on the deployment/stateful sett
+    * ``downscaler/downtime`` annotation on the deployment/stateful set's namespace
+    * ``downscaler/uptime`` annotation on th deployment/stateful set's namespace
+    * ``--default-uptime`` cli argument
+    * ``--default-downtime`` cli argument
+    * ``DEFAULT_UPTIME``environment variable
+    * ``DEFAULT_DOWNTIME``environment variable
 * the deployment's namespace is not part of the exclusion list (``kube-system`` is excluded by default)
 * the deployment's name is not part of the exclusion list
 * the deployment is not marked for exclusion (annotation ``downscaler/exclude: "true"``)
@@ -93,6 +101,23 @@ Available command line options:
 ``--exclude-statefulsets``
     Exclude specific statefulsets from statefulsets, can also be configured via environment variable ``EXCLUDE_STATEFULSETS``
 
+Namespace Defaults
+==================
+
+``DEFAULT_UPTIME``, ``DEFAULT_DOWNTIME`` and ``FORCE_UPTIME`` can also be configured using Namespace annotations. Where configured these values supersede the other global default values.
+
+.. code-block:: yaml
+
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+        name: foo
+        labels:
+            name: foo
+        annotations:
+            downscaler/uptime: Mon-Sun 06:00-21:00 Europe/Berlin
+
+Following annotations are supported on the Namespace level: ``downscaler/uptime``, ``downscaler/downtime`` and ``downscaler/force-uptime``
 
 Contributing
 ============

--- a/README.rst
+++ b/README.rst
@@ -23,8 +23,8 @@ It will scale the deployment's replicas to zero if all of the following conditio
     * ``downscaler/uptime`` annotation on th deployment/stateful set's namespace
     * ``--default-uptime`` cli argument
     * ``--default-downtime`` cli argument
-    * ``DEFAULT_UPTIME``environment variable
-    * ``DEFAULT_DOWNTIME``environment variable
+    * ``DEFAULT_UPTIME`` environment variable
+    * ``DEFAULT_DOWNTIME`` environment variable
 * the deployment's namespace is not part of the exclusion list (``kube-system`` is excluded by default)
 * the deployment's name is not part of the exclusion list
 * the deployment is not marked for exclusion (annotation ``downscaler/exclude: "true"``)

--- a/helm-chart/templates/clusterrole.yaml
+++ b/helm-chart/templates/clusterrole.yaml
@@ -35,4 +35,5 @@ rules:
   - namespaces
   verbs:
   - get
+  - list
 {{- end -}}

--- a/helm-chart/templates/clusterrole.yaml
+++ b/helm-chart/templates/clusterrole.yaml
@@ -29,4 +29,10 @@ rules:
   - list
   - update
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
 {{- end -}}

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - --interval={{ .Values.interval }}
         {{- if .Values.namespace}}
         {{- if .Values.namespace.active_in}}
-        "- --namespace="{{ .Values.namespace.active_in }}
+        - --namespace={{ .Values.namespace.active_in }}
         {{- end }}
         {{- end }}
         {{ if .Values.debug.enable }}- --debug{{end }}

--- a/kube_downscaler/helper.py
+++ b/kube_downscaler/helper.py
@@ -40,6 +40,6 @@ def get_kube_api():
         config = pykube.KubeConfig.from_service_account()
     except FileNotFoundError:
         # local testing
-        config = pykube.KubeConfig.from_file((('KUBECONFIG' in os.environ) and os.environ['KUBECONFIG']) or os.path.expanduser('~/.kube/config'))
+        config = pykube.KubeConfig.from_file(os.getenv('KUBECONFIG', os.path.expanduser('~/.kube/config')))
     api = pykube.HTTPClient(config)
     return api

--- a/kube_downscaler/helper.py
+++ b/kube_downscaler/helper.py
@@ -40,6 +40,6 @@ def get_kube_api():
         config = pykube.KubeConfig.from_service_account()
     except FileNotFoundError:
         # local testing
-        config = pykube.KubeConfig.from_file(os.path.expanduser('~/.kube/config'))
+        config = pykube.KubeConfig.from_file(os.environ['KUBECONFIG'] or os.path.expanduser('~/.kube/config'))
     api = pykube.HTTPClient(config)
     return api

--- a/kube_downscaler/helper.py
+++ b/kube_downscaler/helper.py
@@ -40,6 +40,6 @@ def get_kube_api():
         config = pykube.KubeConfig.from_service_account()
     except FileNotFoundError:
         # local testing
-        config = pykube.KubeConfig.from_file(os.environ['KUBECONFIG'] or os.path.expanduser('~/.kube/config'))
+        config = pykube.KubeConfig.from_file((('KUBECONFIG' in os.environ) and os.environ['KUBECONFIG']) or os.path.expanduser('~/.kube/config'))
     api = pykube.HTTPClient(config)
     return api

--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -95,7 +95,7 @@ def autoscale_resources(api, kind, namespace: str,
             continue
 
         # Override defaults with (optional) annotations from Namespace
-        namespace_obj = pykube.Namespace.objects(api).get_by_name(namespace)
+        namespace_obj = pykube.Namespace.objects(api).get_by_name(resource.namespace)
 
         if namespace_obj.annotations.get(EXCLUDE_ANNOTATION, 'false').lower() != 'false':
             logger.debug('Namespace %s was excluded (because of namespace annotation)', namespace)

--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -96,6 +96,11 @@ def autoscale_resources(api, kind, namespace: str,
 
         # Override defaults with (optional) annotations from Namespace
         namespace_obj = pykube.Namespace.objects(api).get_by_name(namespace)
+
+        if namespace_obj.annotations.get(EXCLUDE_ANNOTATION, 'false').lower() != 'false':
+            logger.debug('Namespace %s was excluded (because of namespace annotation)', namespace)
+            continue
+
         default_uptime = namespace_obj.annotations.get(UPTIME_ANNOTATION, default_uptime)
         default_downtime = namespace_obj.annotations.get(DOWNTIME_ANNOTATION, default_downtime)
         forced_uptime = namespace_obj.annotations.get(FORCE_UPTIME_ANNOTATION, forced_uptime)

--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -101,11 +101,11 @@ def autoscale_resources(api, kind, namespace: str,
             logger.debug('Namespace %s was excluded (because of namespace annotation)', namespace)
             continue
 
-        default_uptime = namespace_obj.annotations.get(UPTIME_ANNOTATION, default_uptime)
-        default_downtime = namespace_obj.annotations.get(DOWNTIME_ANNOTATION, default_downtime)
-        forced_uptime = namespace_obj.annotations.get(FORCE_UPTIME_ANNOTATION, forced_uptime)
+        default_uptime_for_namespace = namespace_obj.annotations.get(UPTIME_ANNOTATION, default_uptime)
+        default_downtime_for_namespace = namespace_obj.annotations.get(DOWNTIME_ANNOTATION, default_downtime)
+        forced_uptime_for_namespace = namespace_obj.annotations.get(FORCE_UPTIME_ANNOTATION, forced_uptime)
 
-        autoscale_resource(resource, default_uptime, default_downtime, forced_uptime, dry_run, now, grace_period)
+        autoscale_resource(resource, default_uptime_for_namespace, default_downtime_for_namespace, forced_uptime_for_namespace, dry_run, now, grace_period)
 
 
 def scale(namespace: str, default_uptime: str, default_downtime: str, kinds: FrozenSet[str],


### PR DESCRIPTION
See #18 and updated Readme.

Example:

```yaml
apiVersion: v1
kind: Namespace
metadata:
    name: foo
    labels:
        name: foo
    annotations:
        downscaler/uptime: Mon-Sun 06:00-21:00 Europe/Berlin
```