### PR TITLE
add condition to prevent infinite downscaling if downscale_replicas != 0

### DIFF
--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -98,7 +98,7 @@ def autoscale_resource(resource: pykube.objects.NamespacedAPIObject, upscale_per
                 resource.replicas = int(original_replicas)
                 resource.annotations[ORIGINAL_REPLICAS_ANNOTATION] = None
                 update_needed = True
-            elif not ignore and not is_uptime and replicas > 0 and replicas > downtime_replicas:
+            elif not ignore and not is_uptime and replicas > 0 and replicas > int(downtime_replicas):
                 target_replicas = int(resource.annotations.get(DOWNTIME_REPLICAS_ANNOTATION, downtime_replicas))
                 if within_grace_period(resource, grace_period, now):
                     logger.info('%s %s/%s within grace period (%ds), not scaling down (yet)',

--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -98,7 +98,7 @@ def autoscale_resource(resource: pykube.objects.NamespacedAPIObject, upscale_per
                 resource.replicas = int(original_replicas)
                 resource.annotations[ORIGINAL_REPLICAS_ANNOTATION] = None
                 update_needed = True
-            elif not ignore and not is_uptime and replicas > 0:
+            elif not ignore and not is_uptime and replicas > 0 and replicas > downtime_replicas:
                 target_replicas = int(resource.annotations.get(DOWNTIME_REPLICAS_ANNOTATION, downtime_replicas))
                 if within_grace_period(resource, grace_period, now):
                     logger.info('%s %s/%s within grace period (%ds), not scaling down (yet)',

--- a/tests/test_autoscale_resource.py
+++ b/tests/test_autoscale_resource.py
@@ -230,6 +230,7 @@ def test_downscale_stack_deployment_ignored():
     resource.update.assert_not_called()
     assert ORIGINAL_REPLICAS_ANNOTATION not in resource.annotations
 
+
 def test_downscale_replicas_not_zero(resource):
     resource.annotations = {EXCLUDE_ANNOTATION: 'false'}
     resource.replicas = 3

--- a/tests/test_autoscale_resource.py
+++ b/tests/test_autoscale_resource.py
@@ -229,3 +229,16 @@ def test_downscale_stack_deployment_ignored():
     assert resource.replicas == 1
     resource.update.assert_not_called()
     assert ORIGINAL_REPLICAS_ANNOTATION not in resource.annotations
+
+def test_downscale_replicas_not_zero(resource):
+    resource.annotations = {EXCLUDE_ANNOTATION: 'false'}
+    resource.replicas = 3
+    now = datetime.strptime('2018-10-23T21:56:00Z', '%Y-%m-%dT%H:%M:%SZ')
+    resource.metadata = {'creationTimestamp': '2018-10-23T21:55:00Z'}
+    autoscale_resource(resource, 'never', 'never', 'never', 'always', False, False, now, 0, 1)
+    assert resource.replicas == 1
+    assert resource.annotations[ORIGINAL_REPLICAS_ANNOTATION] == '3'
+    autoscale_resource(resource, 'never', 'never', 'never', 'always', False, False, now, 0, 1)
+    assert resource.replicas == 1
+    assert resource.annotations[ORIGINAL_REPLICAS_ANNOTATION] == '3'
+    resource.update.assert_called_once()


### PR DESCRIPTION
I faced an issue when downscaling occurred every run of kube downscaler, the root cause was that I was using `downtime_replicas=1`.  