### PR TITLE
Fix: cast downtime replica annotations

### DIFF
--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -58,7 +58,7 @@ def autoscale_resource(resource: pykube.objects.NamespacedAPIObject, upscale_per
     try:
         exclude = namespace_excluded or ignore_resource(resource)
         original_replicas = resource.annotations.get(ORIGINAL_REPLICAS_ANNOTATION)
-        downtime_replicas = resource.annotations.get(DOWNTIME_REPLICAS_ANNOTATION, downtime_replicas)
+        downtime_replicas = int(resource.annotations.get(DOWNTIME_REPLICAS_ANNOTATION, downtime_replicas))
 
         if exclude and not original_replicas:
             logger.debug('%s %s/%s was excluded', resource.kind, resource.namespace, resource.name)
@@ -137,7 +137,7 @@ def autoscale_resources(api, kind, namespace: str,
 
         default_uptime_for_namespace = namespace_obj.annotations.get(UPTIME_ANNOTATION, default_uptime)
         default_downtime_for_namespace = namespace_obj.annotations.get(DOWNTIME_ANNOTATION, default_downtime)
-        default_downtime_replicas_for_namespace = namespace_obj.annotations.get(DOWNTIME_REPLICAS_ANNOTATION, downtime_replicas)
+        default_downtime_replicas_for_namespace = int(namespace_obj.annotations.get(DOWNTIME_REPLICAS_ANNOTATION, downtime_replicas))
         upscale_period_for_namespace = namespace_obj.annotations.get(UPSCALE_PERIOD_ANNOTATION, upscale_period)
         downscale_period_for_namespace = namespace_obj.annotations.get(DOWNSCALE_PERIOD_ANNOTATION, downscale_period)
         forced_uptime_for_namespace = namespace_obj.annotations.get(FORCE_UPTIME_ANNOTATION, forced_uptime)

--- a/tests/test_autoscale_resource.py
+++ b/tests/test_autoscale_resource.py
@@ -114,6 +114,18 @@ def test_scale_up(resource):
     resource.update.assert_called_once()
 
 
+def test_scale_up_downtime_replicas_annotation(resource):
+    """Cli argument downtime-replicas is 1, but for 1 specific deployment we want 0.
+    """
+    resource.annotations = {DOWNTIME_REPLICAS_ANNOTATION: '0', ORIGINAL_REPLICAS_ANNOTATION: "1"}
+    resource.replicas = 0
+    now = datetime.strptime('2018-10-23T15:00:00Z', '%Y-%m-%dT%H:%M:%SZ')
+    resource.metadata = {'creationTimestamp': '2018-10-23T21:55:00Z'}
+    autoscale_resource(resource, 'never', 'never', 'Mon-Fri 07:30-20:30 Europe/Berlin', 'never', False, False, now, 0, 1)
+    assert resource.replicas == 1
+    resource.update.assert_called_once()
+
+
 def test_downtime_replicas_annotation_invalid(resource):
     resource.annotations = {DOWNTIME_REPLICAS_ANNOTATION: 'x'}
     resource.replicas = 2


### PR DESCRIPTION
To avoid false conditions between integers and strings.

When setting arg downtime-replicas to 1, and setting annotation
downtime-replicas to 0 for a specific deployment, deployment was not
scaled-up to original replicas during uptime period.

This behaviour is caused when getting annotations as strings, and
comparing those values to integers, p.e.: `replicas ==
downtime_replicas` is false if types are different.