### PR TITLE
Add support to downscale daemonsets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,12 @@ Available command line options:
 ``--namespace``
     Restrict the downscaler to work only in a single namespace (default: all namespaces). This is mainly useful for deployment scenarios where the deployer of kube-downscaler only has access to a given namespace (instead of cluster access).
 ``--include-resources``
-    Downscale resources of this kind as comma separated list. [deployments, statefulsets, stacks] (default: deployments)
+    Downscale resources of this kind as comma separated list. [deployments, statefulsets, daemonsets, stacks] (default: deployments).
+
+.. code-block:: bash
+
+    --include-resources 'deployments,daemonsets,statefulsets,stacks'
+
 ``--grace-period``
     Grace period in seconds for new deployments before scaling them down (default: 15min). The grace period counts from time of creation of the deployment, i.e. updated deployments will immediately be scaled down regardless of the grace period.
 ``--upscale-period``

--- a/kube_downscaler/cmd.py
+++ b/kube_downscaler/cmd.py
@@ -2,13 +2,14 @@ import os
 
 import argparse
 
-VALID_RESOURCES = frozenset(["deployments", "statefulsets", "stacks"])
+VALID_RESOURCES = frozenset(["deployments", "statefulsets", "daemonsets", "stacks"])
 
 
 def check_include_resources(value):
     resources = frozenset(value.split(','))
     if not resources <= VALID_RESOURCES:
-        raise argparse.ArgumentTypeError(f"--include-resources argument should contain a subset of [{', '.join(VALID_RESOURCES)}]")
+        raise argparse.ArgumentTypeError(f"--include-resources argument should contain a subset of [{', '.join(VALID_RESOURCES)}]. "
+                                         f"Example: --include-resources '{','.join(VALID_RESOURCES)}'")
     return value
 
 
@@ -23,7 +24,9 @@ def get_parser():
     parser.add_argument('--interval', type=int, help='Loop interval (default: 30s)', default=30)
     parser.add_argument('--namespace', help='Namespace')
     parser.add_argument('--include-resources', type=check_include_resources, default="deployments",
-                        help='Downscale resources of this kind as comma separated list. [deployments, statefulsets, stacks] (default: deployments)')
+                        help='Downscale resources of this kind as comma separated list with no spaces. '
+                             '[deployments, statefulsets, daemonsets] (default: deployments). '
+                             'Example: --include-resources \'deployments,statefulsets\'')
     parser.add_argument('--grace-period', type=int,
                         help='Grace period in seconds for deployments before scaling down (default: 15min)',
                         default=900)

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 from pykube.objects import NamespacedAPIObject
 
-from pykube import Deployment, StatefulSet
+from pykube import Deployment, StatefulSet, DaemonSet
 from kube_downscaler.resources.stack import Stack
 
 
@@ -13,7 +13,6 @@ def test_deployment():
     d = Deployment(api_mock, scalable_mock)
     r = d.replicas
     assert r == 3
-
     d.replicas = 10
     assert scalable_mock['spec']['replicas'] == 10
 
@@ -27,6 +26,27 @@ def test_statefulset():
     assert r == 3
     d.replicas = 10
     assert scalable_mock['spec']['replicas'] == 10
+
+
+def test_daemonset_scale_up():
+    api_mock = MagicMock(spec=NamespacedAPIObject, name="APIMock")
+    scalable_mock = {'spec': {'nodeSelector': {'non-existing': 'true'}}}
+    api_mock.obj = MagicMock(name="APIObjMock")
+    d = DaemonSet(api_mock, scalable_mock)
+    nodeselector = d.obj.get('spec')['nodeSelector']['non-existing']
+    assert nodeselector == 'true'
+    d.obj.get('spec').__delitem__('nodeSelector')
+    assert scalable_mock['spec'].get('nodeSelector') is None
+
+
+def test_daemonset_scale_down():
+    api_mock = MagicMock(spec=NamespacedAPIObject, name="APIMock")
+    scalable_mock = {'spec': {}}
+    api_mock.obj = MagicMock(name="APIObjMock")
+    d = DaemonSet(api_mock, scalable_mock)
+    assert 'nodeSelector' not in d.obj['spec']
+    d.obj.get('spec')['nodeSelector'] = {'non-existing': 'true'}
+    assert scalable_mock['spec']['nodeSelector']['non-existing'] == 'true'
 
 
 def test_stack():


### PR DESCRIPTION
There might be some charts who use daemonsets, for example prometheus-operator uses daemonsets to deploy node-exporter pods on each node. Since the way to downscale them is different than scalable resources like deployments, this needs to be addressed separately.

To scale a daemonset effectively means to disable them on all node by using a `nodeSelector` replacing the current one, or adding one if none configured. The nodeSelector value is `{'non-existing': 'true'}`, thus forcing the daemonset pods to not be deployed on any nodes. The full path of the used property is: `spec.template.spec.nodeSelector.non-existing`.

We also need to take care that when the scale up happens the original nodeSelector of the daemonset is set back on the resource by keeping the value in the annotation `downscaler/original-nodeSelector`. There is no configuration option for the downtime nodeSelector as annotation, this being hardcoded to `{'non-existing': 'true'}`.

The original autoscale_resource logic is untouched to ensure regression, and the implemenation to autoscale daemonsets has been extracted to a sperated function autoscale_daemonset which takes the first argument as Daemonset instead of NamespaceAPIObject.

Also updated the error message for --include-resources to provide an example of the right way to pass the arguments for this flag.

Tests
-----------------------------------------
Added tests for autoscaling daemonsets in test_resources.py

Tested on Kubernetes runing in GCloud with daemonsets, statefulsets & deployments:
```kubectl version 
Client Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.3", GitCommit:"b3cbbae08ec52a7fc73d334838e18d17e8512749", GitTreeState:"clean", BuildDate:"2019-11-18T14:56:51Z", GoVersion:"go1.12.13", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"13+", GitVersion:"v1.13.11-gke.14", GitCommit:"56d89863d1033f9668ddd6e1c1aea81cd846ef88", GitTreeState:"clean", BuildDate:"2019-11-07T19:12:22Z", GoVersion:"go1.12.11b4", Compiler:"gc", Platform:"linux/amd64"}
```