### PR TITLE
Fix UnboundLocalError

### DIFF
--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -89,6 +89,7 @@ def autoscale_resource(
             )
         else:
             ignore = False
+            is_uptime = True
 
             upscale_period = resource.annotations.get(
                 UPSCALE_PERIOD_ANNOTATION, upscale_period


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/kube_downscaler/scaler.py", line 122, in autoscale_resource
    is_uptime,
UnboundLocalError: local variable 'is_uptime' referenced before assignment
```