### PR TITLE
Adding support for events

### DIFF
--- a/helm-chart/templates/clusterrole.yaml
+++ b/helm-chart/templates/clusterrole.yaml
@@ -19,6 +19,17 @@ rules:
   - watch
   - list
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - create
+  - watch
+  - list
+  - update
+  - patch
+- apiGroups:
   - extensions
   - apps
   resources:

--- a/kube_downscaler/cmd.py
+++ b/kube_downscaler/cmd.py
@@ -90,4 +90,7 @@ def get_parser():
         help="Default amount of replicas when downscaling (default: 0)",
         default=int(os.getenv("DOWNTIME_REPLICAS", 0)),
     )
+    parser.add_argument(
+        "--enable-events", help="Enabled Events", action="store_true",
+    )
     return parser

--- a/kube_downscaler/main.py
+++ b/kube_downscaler/main.py
@@ -40,6 +40,7 @@ def main(args=None):
         args.grace_period,
         args.interval,
         args.dry_run,
+        args.enable_events,
         args.downtime_replicas,
     )
 
@@ -59,6 +60,7 @@ def run_loop(
     grace_period,
     interval,
     dry_run,
+    enable_events,
     downtime_replicas,
 ):
     handler = shutdown.GracefulShutdown()
@@ -76,6 +78,7 @@ def run_loop(
                 exclude_statefulsets=frozenset(exclude_statefulsets.split(",")),
                 exclude_cronjobs=frozenset(exclude_cronjobs.split(",")),
                 dry_run=dry_run,
+                enable_events=enable_events,
                 grace_period=grace_period,
                 downtime_replicas=downtime_replicas,
             )

--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -68,6 +68,7 @@ def autoscale_resource(
     default_downtime: str,
     forced_uptime: bool,
     dry_run: bool,
+    enable_events: bool,
     now: datetime.datetime,
     grace_period: int,
     downtime_replicas: int,
@@ -175,9 +176,14 @@ def autoscale_resource(
                         uptime,
                         downtime,
                     )
-                    helper.add_event(
-                        resource, "Unsuspending CronJob", "ScaleUp", "Normal", dry_run
-                    )
+                    if enable_events:
+                        helper.add_event(
+                            resource,
+                            "Unsuspending CronJob",
+                            "ScaleUp",
+                            "Normal",
+                            dry_run,
+                        )
                 else:
                     resource.replicas = int(original_replicas)
                     logger.info(
@@ -190,9 +196,14 @@ def autoscale_resource(
                         uptime,
                         downtime,
                     )
-                    helper.add_event(
-                        resource, "Scaling up replicas", "ScaleUp", "Normal", dry_run
-                    )
+                    if enable_events:
+                        helper.add_event(
+                            resource,
+                            "Scaling up replicas",
+                            "ScaleUp",
+                            "Normal",
+                            dry_run,
+                        )
                 resource.annotations[ORIGINAL_REPLICAS_ANNOTATION] = None
                 update_needed = True
 
@@ -227,13 +238,14 @@ def autoscale_resource(
                             uptime,
                             downtime,
                         )
-                        helper.add_event(
-                            resource,
-                            "Suspending CronJob",
-                            "ScaleDown",
-                            "Normal",
-                            dry_run,
-                        )
+                        if enable_events:
+                            helper.add_event(
+                                resource,
+                                "Suspending CronJob",
+                                "ScaleDown",
+                                "Normal",
+                                dry_run,
+                            )
                     else:
                         resource.replicas = target_replicas
                         logger.info(
@@ -246,13 +258,14 @@ def autoscale_resource(
                             uptime,
                             downtime,
                         )
-                        helper.add_event(
-                            resource,
-                            "Scaling down replicas",
-                            "ScaleDown",
-                            "Normal",
-                            dry_run,
-                        )
+                        if enable_events:
+                            helper.add_event(
+                                resource,
+                                "Scaling down replicas",
+                                "ScaleDown",
+                                "Normal",
+                                dry_run,
+                            )
                     resource.annotations[ORIGINAL_REPLICAS_ANNOTATION] = str(replicas)
                     update_needed = True
             if update_needed:
@@ -273,7 +286,8 @@ def autoscale_resource(
             resource.name,
             str(e),
         )
-        helper.add_event(resource, str(e), "ValueError", "Warning", dry_run)
+        if enable_events:
+            helper.add_event(resource, str(e), "ValueError", "Warning", dry_run)
     except Exception as e:
         logger.exception(
             "Failed to process %s %s/%s : %s",
@@ -296,6 +310,7 @@ def autoscale_resources(
     default_downtime: str,
     forced_uptime: bool,
     dry_run: bool,
+    enable_events: bool,
     now: datetime.datetime,
     grace_period: int,
     downtime_replicas: int,
@@ -346,6 +361,7 @@ def autoscale_resources(
             default_downtime_for_namespace,
             forced_uptime_for_namespace,
             dry_run,
+            enable_events,
             now,
             grace_period,
             default_downtime_replicas_for_namespace,
@@ -365,6 +381,7 @@ def scale(
     exclude_statefulsets: FrozenSet[str],
     exclude_cronjobs: FrozenSet[str],
     dry_run: bool,
+    enable_events: bool,
     grace_period: int,
     downtime_replicas: int,
 ):
@@ -386,6 +403,7 @@ def scale(
             default_downtime,
             forced_uptime,
             dry_run,
+            enable_events,
             now,
             grace_period,
             downtime_replicas,
@@ -403,6 +421,7 @@ def scale(
             default_downtime,
             forced_uptime,
             dry_run,
+            enable_events,
             now,
             grace_period,
             downtime_replicas,
@@ -420,6 +439,7 @@ def scale(
             default_downtime,
             forced_uptime,
             dry_run,
+            enable_events,
             now,
             grace_period,
             downtime_replicas,
@@ -437,6 +457,7 @@ def scale(
             default_downtime,
             forced_uptime,
             dry_run,
+            enable_events,
             now,
             grace_period,
             downtime_replicas,

--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -175,7 +175,9 @@ def autoscale_resource(
                         uptime,
                         downtime,
                     )
-                    helper.add_event(resource, "Unsuspending CronJob", "ScaleUp", "Normal", dry_run)
+                    helper.add_event(
+                        resource, "Unsuspending CronJob", "ScaleUp", "Normal", dry_run
+                    )
                 else:
                     resource.replicas = int(original_replicas)
                     logger.info(
@@ -188,7 +190,9 @@ def autoscale_resource(
                         uptime,
                         downtime,
                     )
-                    helper.add_event(resource, "Scaling up replicas", "ScaleUp", "Normal", dry_run)
+                    helper.add_event(
+                        resource, "Scaling up replicas", "ScaleUp", "Normal", dry_run
+                    )
                 resource.annotations[ORIGINAL_REPLICAS_ANNOTATION] = None
                 update_needed = True
 
@@ -223,7 +227,13 @@ def autoscale_resource(
                             uptime,
                             downtime,
                         )
-                        helper.add_event(resource, "Suspending CronJob", "ScaleDown", "Normal", dry_run)
+                        helper.add_event(
+                            resource,
+                            "Suspending CronJob",
+                            "ScaleDown",
+                            "Normal",
+                            dry_run,
+                        )
                     else:
                         resource.replicas = target_replicas
                         logger.info(
@@ -236,7 +246,13 @@ def autoscale_resource(
                             uptime,
                             downtime,
                         )
-                        helper.add_event(resource, "Scaling down replicas", "ScaleDown", "Normal", dry_run)
+                        helper.add_event(
+                            resource,
+                            "Scaling down replicas",
+                            "ScaleDown",
+                            "Normal",
+                            dry_run,
+                        )
                     resource.annotations[ORIGINAL_REPLICAS_ANNOTATION] = str(replicas)
                     update_needed = True
             if update_needed:

--- a/tests/test_autoscale_resource.py
+++ b/tests/test_autoscale_resource.py
@@ -3,13 +3,11 @@ import logging
 from datetime import datetime
 from datetime import timezone
 from unittest.mock import MagicMock
-from unittest.mock import Mock
 
 import pykube
 import pytest
 from pykube import Deployment
 
-from kube_downscaler import helper
 from kube_downscaler.resources.stack import Stack
 from kube_downscaler.scaler import autoscale_resource
 from kube_downscaler.scaler import DOWNSCALE_PERIOD_ANNOTATION
@@ -17,8 +15,6 @@ from kube_downscaler.scaler import DOWNTIME_REPLICAS_ANNOTATION
 from kube_downscaler.scaler import EXCLUDE_ANNOTATION
 from kube_downscaler.scaler import ORIGINAL_REPLICAS_ANNOTATION
 from kube_downscaler.scaler import UPSCALE_PERIOD_ANNOTATION
-
-helper.create_event = Mock(return_value=None)
 
 
 @pytest.fixture
@@ -31,7 +27,10 @@ def resource():
     return res
 
 
-def test_swallow_exception(resource, caplog):
+def test_swallow_exception(monkeypatch, resource, caplog):
+    monkeypatch.setattr(
+        "kube_downscaler.scaler.helper.add_event", MagicMock(return_value=None)
+    )
     caplog.set_level(logging.ERROR)
     resource.annotations = {}
     resource.replicas = 1

--- a/tests/test_autoscale_resource.py
+++ b/tests/test_autoscale_resource.py
@@ -3,11 +3,13 @@ import logging
 from datetime import datetime
 from datetime import timezone
 from unittest.mock import MagicMock
+from unittest.mock import Mock
 
 import pykube
 import pytest
 from pykube import Deployment
 
+from kube_downscaler import helper
 from kube_downscaler.resources.stack import Stack
 from kube_downscaler.scaler import autoscale_resource
 from kube_downscaler.scaler import DOWNSCALE_PERIOD_ANNOTATION
@@ -15,6 +17,8 @@ from kube_downscaler.scaler import DOWNTIME_REPLICAS_ANNOTATION
 from kube_downscaler.scaler import EXCLUDE_ANNOTATION
 from kube_downscaler.scaler import ORIGINAL_REPLICAS_ANNOTATION
 from kube_downscaler.scaler import UPSCALE_PERIOD_ANNOTATION
+
+helper.create_event = Mock(return_value=None)
 
 
 @pytest.fixture

--- a/tests/test_autoscale_resource.py
+++ b/tests/test_autoscale_resource.py
@@ -175,6 +175,19 @@ def test_forced_uptime(resource):
     resource.update.assert_not_called()
 
 
+def test_autoscale_bad_resource():
+    now = datetime.strptime("2018-10-23T21:56:00Z", "%Y-%m-%dT%H:%M:%SZ").replace(
+        tzinfo=timezone.utc
+    )
+    try:
+        autoscale_resource(
+            None, "never", "never", "never", "always", False, False, now, 0, 0
+        )
+        raise AssertionError("Failed to error out with a bad resource")
+    except Exception:
+        pass
+
+
 def test_scale_up(resource):
     resource.annotations = {
         EXCLUDE_ANNOTATION: "false",

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,52 @@
+from unittest.mock import MagicMock
+
+import pytest
+from pykube.query import Query
+
+from kube_downscaler import helper
+
+
+@pytest.fixture
+def resource():
+    res = MagicMock()
+    res.kind = "MockResource"
+    res.namespace = "mock"
+    res.name = "res-1"
+    res.annotations = {}
+    res.metadata = {"uid": "id-1"}
+    return res
+
+
+@pytest.fixture
+def event():
+    res = MagicMock()
+    res.kind = "Event"
+    res.namespace = "mock"
+    res.name = "event-1"
+    res.message = "test message"
+    res.obj = {"count": 1, "message": "test message"}
+    res.annotations = {}
+    return res
+
+
+def test_add_event_update_existing(monkeypatch, resource, event):
+    query = Query(resource.api, event, resource.namespace)
+    monkeypatch.setattr("pykube.query.Query.get_or_none", MagicMock(return_value=event))
+    monkeypatch.setattr("pykube.objects.Event.objects", MagicMock(return_value=query))
+    e = helper.add_event(resource, "test message", "reason", "Normal", False)
+    assert e.obj["count"] == 2
+    event.update.assert_called_once()
+
+
+def test_create_event(monkeypatch, resource, event):
+    monkeypatch.setattr("pykube.objects.Event.create", MagicMock(return_value=event))
+    e = helper.create_event(resource, "test message", "reason", "Normal", False)
+    assert e.obj["count"] == 1
+    event.update.assert_not_called()
+
+
+def test_add_event(monkeypatch, resource, event):
+    monkeypatch.setattr("pykube.objects.Event.create", MagicMock(return_value=event))
+    e = helper.add_event(resource, "test message", "reason", "Normal", False)
+    assert e.obj["count"] == 1
+    event.update.assert_not_called()

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -1,10 +1,14 @@
 import json
 from unittest.mock import MagicMock
+from unittest.mock import Mock
 
+from kube_downscaler import helper
 from kube_downscaler.scaler import DOWNTIME_REPLICAS_ANNOTATION
 from kube_downscaler.scaler import EXCLUDE_ANNOTATION
 from kube_downscaler.scaler import ORIGINAL_REPLICAS_ANNOTATION
 from kube_downscaler.scaler import scale
+
+helper.add_event = Mock(return_value=None)
 
 
 def test_scaler_always_up(monkeypatch):

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -1,14 +1,10 @@
 import json
 from unittest.mock import MagicMock
-from unittest.mock import Mock
 
-from kube_downscaler import helper
 from kube_downscaler.scaler import DOWNTIME_REPLICAS_ANNOTATION
 from kube_downscaler.scaler import EXCLUDE_ANNOTATION
 from kube_downscaler.scaler import ORIGINAL_REPLICAS_ANNOTATION
 from kube_downscaler.scaler import scale
-
-helper.add_event = Mock(return_value=None)
 
 
 def test_scaler_always_up(monkeypatch):
@@ -70,6 +66,9 @@ def test_scaler_namespace_excluded(monkeypatch):
     api = MagicMock()
     monkeypatch.setattr(
         "kube_downscaler.scaler.helper.get_kube_api", MagicMock(return_value=api)
+    )
+    monkeypatch.setattr(
+        "kube_downscaler.scaler.helper.add_event", MagicMock(return_value=None)
     )
 
     def get(url, version, **kwargs):
@@ -144,6 +143,9 @@ def test_scaler_namespace_excluded_via_annotation(monkeypatch):
     api = MagicMock()
     monkeypatch.setattr(
         "kube_downscaler.scaler.helper.get_kube_api", MagicMock(return_value=api)
+    )
+    monkeypatch.setattr(
+        "kube_downscaler.scaler.helper.add_event", MagicMock(return_value=None)
     )
 
     def get(url, version, **kwargs):
@@ -221,6 +223,9 @@ def test_scaler_down_to(monkeypatch):
     monkeypatch.setattr(
         "kube_downscaler.scaler.helper.get_kube_api", MagicMock(return_value=api)
     )
+    monkeypatch.setattr(
+        "kube_downscaler.scaler.helper.add_event", MagicMock(return_value=None)
+    )
     SCALE_TO = 1
 
     def get(url, version, **kwargs):
@@ -277,6 +282,9 @@ def test_scaler_down_to_upscale(monkeypatch):
     api = MagicMock()
     monkeypatch.setattr(
         "kube_downscaler.scaler.helper.get_kube_api", MagicMock(return_value=api)
+    )
+    monkeypatch.setattr(
+        "kube_downscaler.scaler.helper.add_event", MagicMock(return_value=None)
     )
     SCALE_TO = 1
     ORIGINAL = 3
@@ -342,6 +350,9 @@ def test_scaler_upscale_on_exclude(monkeypatch):
     monkeypatch.setattr(
         "kube_downscaler.scaler.helper.get_kube_api", MagicMock(return_value=api)
     )
+    monkeypatch.setattr(
+        "kube_downscaler.scaler.helper.add_event", MagicMock(return_value=None)
+    )
     ORIGINAL_REPLICAS = 2
 
     def get(url, version, **kwargs):
@@ -406,6 +417,9 @@ def test_scaler_upscale_on_exclude_namespace(monkeypatch):
     api = MagicMock()
     monkeypatch.setattr(
         "kube_downscaler.scaler.helper.get_kube_api", MagicMock(return_value=api)
+    )
+    monkeypatch.setattr(
+        "kube_downscaler.scaler.helper.add_event", MagicMock(return_value=None)
     )
     ORIGINAL_REPLICAS = 2
 
@@ -524,6 +538,9 @@ def test_scaler_namespace_annotation_replicas(monkeypatch):
     monkeypatch.setattr(
         "kube_downscaler.scaler.helper.get_kube_api", MagicMock(return_value=api)
     )
+    monkeypatch.setattr(
+        "kube_downscaler.scaler.helper.add_event", MagicMock(return_value=None)
+    )
     SCALE_TO = 3
 
     def get(url, version, **kwargs):
@@ -582,6 +599,9 @@ def test_scaler_cronjob_suspend(monkeypatch):
     api = MagicMock()
     monkeypatch.setattr(
         "kube_downscaler.scaler.helper.get_kube_api", MagicMock(return_value=api)
+    )
+    monkeypatch.setattr(
+        "kube_downscaler.scaler.helper.add_event", MagicMock(return_value=None)
     )
 
     def get(url, version, **kwargs):
@@ -648,6 +668,9 @@ def test_scaler_cronjob_unsuspend(monkeypatch):
     api = MagicMock()
     monkeypatch.setattr(
         "kube_downscaler.scaler.helper.get_kube_api", MagicMock(return_value=api)
+    )
+    monkeypatch.setattr(
+        "kube_downscaler.scaler.helper.add_event", MagicMock(return_value=None)
     )
 
     def get(url, version, **kwargs):

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -57,6 +57,7 @@ def test_scaler_always_up(monkeypatch):
         dry_run=False,
         grace_period=300,
         downtime_replicas=0,
+        enable_events=False,
     )
 
     api.patch.assert_not_called()
@@ -66,9 +67,6 @@ def test_scaler_namespace_excluded(monkeypatch):
     api = MagicMock()
     monkeypatch.setattr(
         "kube_downscaler.scaler.helper.get_kube_api", MagicMock(return_value=api)
-    )
-    monkeypatch.setattr(
-        "kube_downscaler.scaler.helper.add_event", MagicMock(return_value=None)
     )
 
     def get(url, version, **kwargs):
@@ -121,6 +119,7 @@ def test_scaler_namespace_excluded(monkeypatch):
         dry_run=False,
         grace_period=300,
         downtime_replicas=0,
+        enable_events=False,
     )
 
     assert api.patch.call_count == 1
@@ -143,9 +142,6 @@ def test_scaler_namespace_excluded_via_annotation(monkeypatch):
     api = MagicMock()
     monkeypatch.setattr(
         "kube_downscaler.scaler.helper.get_kube_api", MagicMock(return_value=api)
-    )
-    monkeypatch.setattr(
-        "kube_downscaler.scaler.helper.add_event", MagicMock(return_value=None)
     )
 
     def get(url, version, **kwargs):
@@ -200,6 +196,7 @@ def test_scaler_namespace_excluded_via_annotation(monkeypatch):
         dry_run=False,
         grace_period=300,
         downtime_replicas=0,
+        enable_events=False,
     )
 
     assert api.patch.call_count == 1
@@ -271,6 +268,7 @@ def test_scaler_down_to(monkeypatch):
         dry_run=False,
         grace_period=300,
         downtime_replicas=0,
+        enable_events=True,
     )
 
     assert api.patch.call_count == 1
@@ -335,6 +333,7 @@ def test_scaler_down_to_upscale(monkeypatch):
         dry_run=False,
         grace_period=300,
         downtime_replicas=0,
+        enable_events=True,
     )
 
     assert api.patch.call_count == 1
@@ -349,9 +348,6 @@ def test_scaler_upscale_on_exclude(monkeypatch):
     api = MagicMock()
     monkeypatch.setattr(
         "kube_downscaler.scaler.helper.get_kube_api", MagicMock(return_value=api)
-    )
-    monkeypatch.setattr(
-        "kube_downscaler.scaler.helper.add_event", MagicMock(return_value=None)
     )
     ORIGINAL_REPLICAS = 2
 
@@ -400,6 +396,7 @@ def test_scaler_upscale_on_exclude(monkeypatch):
         dry_run=False,
         grace_period=300,
         downtime_replicas=0,
+        enable_events=False,
     )
 
     assert api.patch.call_count == 1
@@ -417,9 +414,6 @@ def test_scaler_upscale_on_exclude_namespace(monkeypatch):
     api = MagicMock()
     monkeypatch.setattr(
         "kube_downscaler.scaler.helper.get_kube_api", MagicMock(return_value=api)
-    )
-    monkeypatch.setattr(
-        "kube_downscaler.scaler.helper.add_event", MagicMock(return_value=None)
     )
     ORIGINAL_REPLICAS = 2
 
@@ -467,6 +461,7 @@ def test_scaler_upscale_on_exclude_namespace(monkeypatch):
         dry_run=False,
         grace_period=300,
         downtime_replicas=0,
+        enable_events=False,
     )
 
     assert api.patch.call_count == 1
@@ -528,6 +523,7 @@ def test_scaler_always_upscale(monkeypatch):
         dry_run=False,
         grace_period=300,
         downtime_replicas=0,
+        enable_events=False,
     )
 
     api.patch.assert_not_called()
@@ -537,9 +533,6 @@ def test_scaler_namespace_annotation_replicas(monkeypatch):
     api = MagicMock()
     monkeypatch.setattr(
         "kube_downscaler.scaler.helper.get_kube_api", MagicMock(return_value=api)
-    )
-    monkeypatch.setattr(
-        "kube_downscaler.scaler.helper.add_event", MagicMock(return_value=None)
     )
     SCALE_TO = 3
 
@@ -588,6 +581,7 @@ def test_scaler_namespace_annotation_replicas(monkeypatch):
         dry_run=False,
         grace_period=300,
         downtime_replicas=0,
+        enable_events=False,
     )
 
     assert api.patch.call_count == 1
@@ -647,6 +641,7 @@ def test_scaler_cronjob_suspend(monkeypatch):
         dry_run=False,
         grace_period=300,
         downtime_replicas=0,
+        enable_events=True,
     )
 
     assert api.patch.call_count == 1
@@ -724,6 +719,7 @@ def test_scaler_cronjob_unsuspend(monkeypatch):
         dry_run=False,
         grace_period=300,
         downtime_replicas=0,
+        enable_events=True,
     )
 
     assert api.patch.call_count == 1
@@ -790,6 +786,7 @@ def test_scaler_downscale_period_no_error(monkeypatch, caplog):
         dry_run=False,
         grace_period=300,
         downtime_replicas=0,
+        enable_events=False,
     )
 
     assert api.patch.call_count == 0


### PR DESCRIPTION
Adding basic event support for https://github.com/hjacobs/kube-downscaler/issues/80.

Events on ScaleUp and ScaleDown are generated and show up when describing the object.  An event is also generated if the time spec value format is bad.  This way users are notified on a bad configuration if they do no have access to the controller logs.