### PR TITLE
Support custom deployment/update time annotation for grace period

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,6 +153,11 @@ Available command line options:
     Exclude specific statefulsets from statefulsets, can also be configured via environment variable ``EXCLUDE_STATEFULSETS``
 ``--downtime-replicas``
     Default value of replicas to downscale to, the annotation ``downscaler/downtime-replicas`` takes precedence over this value.
+``--deployment-time-annotation``
+    Optional: name of the annotation that would be used instead of the creation timestamp of the resource.
+    This option should be used if you want the resources to be kept scaled up during a grace period (``--grace-period``) after a deployment.
+    The format of the annotation's timestamp value must be exactly the same as for Kubernetes' ``creationTimestamp``: ``%Y-%m-%dT%H:%M:%SZ``.
+    Recommended: set this annotation by your deployment tooling automatically.
 
 Namespace Defaults
 ==================

--- a/kube_downscaler/cmd.py
+++ b/kube_downscaler/cmd.py
@@ -90,4 +90,8 @@ def get_parser():
         help="Default amount of replicas when downscaling (default: 0)",
         default=int(os.getenv("DOWNTIME_REPLICAS", 0)),
     )
+    parser.add_argument(
+        "--deployment-time-annotation",
+        help="Annotation that contains a resource's last deployment time, overrides creationTime. Use in combination with --grace-period.",
+    )
     return parser

--- a/kube_downscaler/main.py
+++ b/kube_downscaler/main.py
@@ -41,6 +41,7 @@ def main(args=None):
         args.interval,
         args.dry_run,
         args.downtime_replicas,
+        args.deployment_time_annotation,
     )
 
 
@@ -60,6 +61,7 @@ def run_loop(
     interval,
     dry_run,
     downtime_replicas,
+    deployment_time_annotation=None,
 ):
     handler = shutdown.GracefulShutdown()
     while True:
@@ -78,6 +80,7 @@ def run_loop(
                 dry_run=dry_run,
                 grace_period=grace_period,
                 downtime_replicas=downtime_replicas,
+                deployment_time_annotation=deployment_time_annotation,
             )
         except Exception as e:
             logger.exception("Failed to autoscale : %s", e)

--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -222,7 +222,9 @@ def autoscale_resource(
                         DOWNTIME_REPLICAS_ANNOTATION, downtime_replicas
                     )
                 )
-                if within_grace_period(resource, grace_period, now):
+                if within_grace_period(
+                    resource, grace_period, now, deployment_time_annotation
+                ):
                     logger.info(
                         "%s %s/%s within grace period (%ds), not scaling down (yet)",
                         resource.kind,

--- a/tests/test_grace_period.py
+++ b/tests/test_grace_period.py
@@ -6,8 +6,10 @@ from pykube import Deployment
 
 from kube_downscaler.scaler import within_grace_period
 
+ANNOTATION_NAME = "my-deployment-time"
 
-def test_within_grace_period():
+
+def test_within_grace_period_creation_time():
     now = datetime.now(timezone.utc)
     ts = now - timedelta(minutes=5)
     deploy = Deployment(
@@ -27,10 +29,59 @@ def test_within_grace_period_deployment_time_annotation():
             "metadata": {
                 "creationTimestamp": creation_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "annotations": {
-                    "my-deployment-time": deployment_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+                    ANNOTATION_NAME: deployment_time.strftime("%Y-%m-%dT%H:%M:%SZ")
                 },
             }
         },
     )
-    assert within_grace_period(deploy, 900, now)
-    assert not within_grace_period(deploy, 180, now)
+    assert within_grace_period(
+        deploy, 900, now, deployment_time_annotation=ANNOTATION_NAME
+    )
+    assert not within_grace_period(
+        deploy, 180, now, deployment_time_annotation=ANNOTATION_NAME
+    )
+
+
+def test_within_grace_period_without_deployment_time_annotation():
+    now = datetime.now(timezone.utc)
+    creation_time = now - timedelta(days=7)
+
+    # without annotation set
+    deploy = Deployment(
+        None,
+        {
+            "metadata": {
+                "creationTimestamp": creation_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+            }
+        },
+    )
+    assert not within_grace_period(
+        deploy, 900, now, deployment_time_annotation=ANNOTATION_NAME
+    )
+    assert not within_grace_period(
+        deploy, 180, now, deployment_time_annotation=ANNOTATION_NAME
+    )
+
+
+def test_within_grace_period_wrong_deployment_time_annotation():
+    now = datetime.now(timezone.utc)
+    creation_time = now - timedelta(days=7)
+
+    deploy = Deployment(
+        None,
+        {
+            "metadata": {
+                # name & namespace must be set as it will be logged (warning message)
+                "name": "my-deploy",
+                "namespace": "my-ns",
+                "creationTimestamp": creation_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "annotations": {ANNOTATION_NAME: "some-invalid-value"},
+            }
+        },
+    )
+    assert not within_grace_period(
+        deploy, 900, now, deployment_time_annotation=ANNOTATION_NAME
+    )
+    assert not within_grace_period(
+        deploy, 180, now, deployment_time_annotation=ANNOTATION_NAME
+    )

--- a/tests/test_grace_period.py
+++ b/tests/test_grace_period.py
@@ -15,3 +15,22 @@ def test_within_grace_period():
     )
     assert within_grace_period(deploy, 900, now)
     assert not within_grace_period(deploy, 180, now)
+
+
+def test_within_grace_period_deployment_time_annotation():
+    now = datetime.now(timezone.utc)
+    creation_time = now - timedelta(days=7)
+    deployment_time = now - timedelta(minutes=5)
+    deploy = Deployment(
+        None,
+        {
+            "metadata": {
+                "creationTimestamp": creation_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "annotations": {
+                    "my-deployment-time": deployment_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+                },
+            }
+        },
+    )
+    assert within_grace_period(deploy, 900, now)
+    assert not within_grace_period(deploy, 180, now)


### PR DESCRIPTION
Fixes #87.

Add support to use `--grace-period` in combination with a custom annotation which contains the resource deployment/update time (`--deployment-time-annotation`).