### PR TITLE
Support stacks with HPA

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -29,6 +29,16 @@ rules:
   - update
   - patch
 - apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch
+- apiGroups:
   - zalando.org
   resources:
   - stacks

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -28,6 +28,16 @@ rules:
   - list
   - update
   - patch
+- apiGroups:
+  - zalando.org
+  resources:
+  - stacks
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/kube_downscaler/helper.py
+++ b/kube_downscaler/helper.py
@@ -1,5 +1,4 @@
 import datetime
-import os
 import re
 from typing import Match
 
@@ -65,10 +64,6 @@ def _matches_absolute_time_spec(time: datetime.datetime, match: Match):
 
 
 def get_kube_api():
-    try:
-        config = pykube.KubeConfig.from_service_account()
-    except FileNotFoundError:
-        # local testing
-        config = pykube.KubeConfig.from_file(os.getenv("KUBECONFIG", "~/.kube/config"))
+    config = pykube.KubeConfig.from_env()
     api = pykube.HTTPClient(config)
     return api

--- a/kube_downscaler/resources/stack.py
+++ b/kube_downscaler/resources/stack.py
@@ -23,8 +23,9 @@ class Stack(NamespacedAPIObject, ReplicatedMixin):
 
     @property
     def replicas(self):
-        if "replicas" in self.obj["spec"]:
-            return self.obj["spec"]["replicas"]
+        replicas = self.obj["spec"].get("replicas")
+        if replicas is not None:
+            return replicas
         else:
             return self.get_autoscaling_max_replicas()
 

--- a/kube_downscaler/resources/stack.py
+++ b/kube_downscaler/resources/stack.py
@@ -1,12 +1,43 @@
 from pykube.objects import NamespacedAPIObject
 from pykube.objects import ReplicatedMixin
-from pykube.objects import ScalableMixin
 
 
-class Stack(NamespacedAPIObject, ReplicatedMixin, ScalableMixin):
+class Stack(NamespacedAPIObject, ReplicatedMixin):
 
     """Support the Stack resource (https://github.com/zalando-incubator/stackset-controller)."""
 
     version = "zalando.org/v1"
     endpoint = "stacks"
     kind = "Stack"
+
+    def get_autoscaling_max_replicas(self):
+        spec = self.obj["spec"]
+        if "autoscaler" in spec:
+            # see https://github.com/zalando-incubator/stackset-controller/blob/2baddca617e2b76e34976357765206280cfd382e/pkg/apis/zalando.org/v1/types.go#L116
+            return int(spec["autoscaler"].get("maxReplicas", 0))
+        elif "horizontalPodAutoscaler" in spec:
+            # see https://github.com/zalando-incubator/stackset-controller/blob/2baddca617e2b76e34976357765206280cfd382e/pkg/apis/zalando.org/v1/types.go#L139
+            return int(spec["horizontalPodAutoscaler"].get("maxReplicas", 0))
+        return None
+
+    @property
+    def replicas(self):
+        if "replicas" in self.obj["spec"]:
+            return self.obj["spec"]["replicas"]
+        else:
+            return self.get_autoscaling_max_replicas()
+
+    @replicas.setter
+    def replicas(self, value):
+        max_replicas = self.get_autoscaling_max_replicas()
+        if max_replicas is not None:
+            if value == max_replicas:
+                # reset to autoscaling
+                if "replicas" in self.obj["spec"]:
+                    # => remove manual replica count
+                    del self.obj["spec"]["replicas"]
+            else:
+                self.obj["spec"]["replicas"] = value
+        else:
+            # no autoscaling configured
+            self.obj["spec"]["replicas"] = value

--- a/kube_downscaler/resources/stack.py
+++ b/kube_downscaler/resources/stack.py
@@ -11,6 +11,7 @@ class Stack(NamespacedAPIObject, ReplicatedMixin):
     kind = "Stack"
 
     def get_autoscaling_max_replicas(self):
+        """Return the Stack's HPA maxReplicas property or None if no autoscaling is configured."""
         spec = self.obj["spec"]
         if "autoscaler" in spec:
             # see https://github.com/zalando-incubator/stackset-controller/blob/2baddca617e2b76e34976357765206280cfd382e/pkg/apis/zalando.org/v1/types.go#L116
@@ -35,11 +36,13 @@ class Stack(NamespacedAPIObject, ReplicatedMixin):
                 # reset to autoscaling
                 if "replicas" in self.obj["spec"]:
                     # => remove manual replica count
-                    # note that it's set to 'None' instead of deleting the property
+                    # note that we set 'None' instead of deleting the property
                     # (because of strategic object merge)
                     self.obj["spec"]["replicas"] = None
             else:
+                # downscale to the given value
                 self.obj["spec"]["replicas"] = value
         else:
             # no autoscaling configured
+            # => we can use the replicas property directly
             self.obj["spec"]["replicas"] = value

--- a/kube_downscaler/resources/stack.py
+++ b/kube_downscaler/resources/stack.py
@@ -35,7 +35,9 @@ class Stack(NamespacedAPIObject, ReplicatedMixin):
                 # reset to autoscaling
                 if "replicas" in self.obj["spec"]:
                     # => remove manual replica count
-                    del self.obj["spec"]["replicas"]
+                    # note that it's set to 'None' instead of deleting the property
+                    # (because of strategic object merge)
+                    self.obj["spec"]["replicas"] = None
             else:
                 self.obj["spec"]["replicas"] = value
         else:

--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -92,8 +92,8 @@ def autoscale_resource(
     forced_uptime: bool,
     dry_run: bool,
     now: datetime.datetime,
-    grace_period: int,
-    downtime_replicas: int,
+    grace_period: int = 0,
+    downtime_replicas: int = 0,
     namespace_excluded=False,
     deployment_time_annotation: Optional[str] = None,
 ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "kube-downscaler"
-version = "2019.1.1dev0"
+version = "2020.1.1dev0"
 description = "Scale down Kubernetes deployments after work hours"
 authors = ["Henning Jacobs <henning@jacobs1.de>"]
 

--- a/tests/test_autoscale_resource.py
+++ b/tests/test_autoscale_resource.py
@@ -523,6 +523,36 @@ def test_downscale_replicas_not_zero(resource):
     resource.update.assert_called_once()
 
 
+def test_downscale_stack_with_autoscaling():
+    stack = Stack(
+        None,
+        {
+            "metadata": {
+                "name": "my-stack",
+                "namespace": "my-ns",
+                "creationTimestamp": "2018-10-23T21:55:00Z",
+            },
+            "spec": {"horizontalPodAutoscaler": {"maxReplicas": 4}},
+        },
+    )
+
+    now = datetime.strptime("2018-10-23T21:56:00Z", "%Y-%m-%dT%H:%M:%SZ").replace(
+        tzinfo=timezone.utc
+    )
+    assert stack.replicas == 4
+    autoscale_resource(
+        stack,
+        upscale_period="never",
+        downscale_period="never",
+        default_uptime="never",
+        default_downtime="always",
+        forced_uptime=False,
+        dry_run=True,
+        now=now,
+    )
+    assert stack.replicas == 0
+
+
 def test_upscale_stack_with_autoscaling():
     stack = Stack(
         None,

--- a/tests/test_autoscale_resource.py
+++ b/tests/test_autoscale_resource.py
@@ -521,3 +521,36 @@ def test_downscale_replicas_not_zero(resource):
     assert resource.replicas == 1
     assert resource.annotations[ORIGINAL_REPLICAS_ANNOTATION] == "3"
     resource.update.assert_called_once()
+
+
+def test_upscale_stack_with_autoscaling():
+    stack = Stack(
+        None,
+        {
+            "metadata": {
+                "name": "my-stack",
+                "namespace": "my-ns",
+                "creationTimestamp": "2018-10-23T21:55:00Z",
+                "annotations": {ORIGINAL_REPLICAS_ANNOTATION: 4},
+            },
+            "spec": {"autoscaler": {"maxReplicas": 4}, "replicas": 0},
+        },
+    )
+
+    now = datetime.strptime("2018-10-23T21:56:00Z", "%Y-%m-%dT%H:%M:%SZ").replace(
+        tzinfo=timezone.utc
+    )
+    assert stack.replicas == 0
+    autoscale_resource(
+        stack,
+        upscale_period="never",
+        downscale_period="never",
+        default_uptime="always",
+        default_downtime="never",
+        forced_uptime=False,
+        dry_run=True,
+        now=now,
+    )
+    assert stack.obj["spec"]["replicas"] is None
+    assert stack.replicas == 4
+    assert stack.annotations[ORIGINAL_REPLICAS_ANNOTATION] is None


### PR DESCRIPTION
Downscale `Stack` resources which have `autoscaler` or `horizontalPodAutoscaler` configured:

* set the `replicas` value to zero for downscaling
* remove the `replicas` values for upscaling --- this will enable autoscaling again

Fixes #92.