### PR TITLE
Ignore invalid annotation value for downscaler/exclude-until

### DIFF
--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -106,7 +106,7 @@ def ignore_resource(
             until_ts = parse_time(exclude_until)
         except ValueError as e:
             logger.warning(
-                f"Invalid {EXCLUDE_UNTIL_ANNOTATION} on {resource.namespace}/{resource.name}: {e}"
+                f"Invalid annotation value for '{EXCLUDE_UNTIL_ANNOTATION}' on {resource.namespace}/{resource.name}: {e}"
             )
             # we will ignore the invalid timestamp and treat the resource as not excluded
             return False

--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -102,7 +102,14 @@ def ignore_resource(
 
     exclude_until = resource.annotations.get(EXCLUDE_UNTIL_ANNOTATION)
     if exclude_until:
-        until_ts = parse_time(exclude_until)
+        try:
+            until_ts = parse_time(exclude_until)
+        except ValueError as e:
+            logger.warning(
+                f"Invalid {EXCLUDE_UNTIL_ANNOTATION} on {resource.namespace}/{resource.name}: {e}"
+            )
+            # we will ignore the invalid timestamp and treat the resource as not excluded
+            return False
         if now < until_ts:
             return True
 

--- a/tests/test_autoscale_resource.py
+++ b/tests/test_autoscale_resource.py
@@ -61,7 +61,8 @@ def test_exclude(resource):
     assert ORIGINAL_REPLICAS_ANNOTATION not in resource.annotations
 
 
-def test_exclude_until_invalid_time(resource):
+def test_exclude_until_invalid_time(resource, caplog):
+    caplog.set_level(logging.WARNING)
     resource.annotations = {EXCLUDE_UNTIL_ANNOTATION: "some-invalid-timestamp"}
     resource.replicas = 1
     now = datetime.strptime("2018-10-23T21:56:00Z", "%Y-%m-%dT%H:%M:%SZ").replace(
@@ -82,6 +83,10 @@ def test_exclude_until_invalid_time(resource):
     assert resource.annotations[ORIGINAL_REPLICAS_ANNOTATION] == "1"
     # dry run will update the object properties, but won't call the Kubernetes API (update)
     resource.update.assert_not_called()
+
+    # check that the warning was logged
+    msg = "Invalid annotation value for 'downscaler/exclude-until' on mock/res-1: time data 'some-invalid-timestamp' does not match any format (%Y-%m-%dT%H:%M:%SZ, %Y-%m-%dT%H:%M, %Y-%m-%d %H:%M, %Y-%m-%d)"
+    assert caplog.record_tuples == [("kube_downscaler.scaler", logging.WARNING, msg)]
 
 
 def test_dry_run(resource):

--- a/tests/test_autoscale_resource.py
+++ b/tests/test_autoscale_resource.py
@@ -13,6 +13,7 @@ from kube_downscaler.scaler import autoscale_resource
 from kube_downscaler.scaler import DOWNSCALE_PERIOD_ANNOTATION
 from kube_downscaler.scaler import DOWNTIME_REPLICAS_ANNOTATION
 from kube_downscaler.scaler import EXCLUDE_ANNOTATION
+from kube_downscaler.scaler import EXCLUDE_UNTIL_ANNOTATION
 from kube_downscaler.scaler import ORIGINAL_REPLICAS_ANNOTATION
 from kube_downscaler.scaler import UPSCALE_PERIOD_ANNOTATION
 
@@ -58,6 +59,29 @@ def test_exclude(resource):
     assert resource.replicas == 1
     resource.update.assert_not_called()
     assert ORIGINAL_REPLICAS_ANNOTATION not in resource.annotations
+
+
+def test_exclude_until_invalid_time(resource):
+    resource.annotations = {EXCLUDE_UNTIL_ANNOTATION: "some-invalid-timestamp"}
+    resource.replicas = 1
+    now = datetime.strptime("2018-10-23T21:56:00Z", "%Y-%m-%dT%H:%M:%SZ").replace(
+        tzinfo=timezone.utc
+    )
+    resource.metadata = {"creationTimestamp": "2018-10-23T21:55:00Z"}
+    autoscale_resource(
+        resource,
+        "never",
+        "never",
+        "never",
+        "always",
+        forced_uptime=False,
+        dry_run=True,
+        now=now,
+    )
+    assert resource.replicas == 0
+    assert resource.annotations[ORIGINAL_REPLICAS_ANNOTATION] == "1"
+    # dry run will update the object properties, but won't call the Kubernetes API (update)
+    resource.update.assert_not_called()
 
 
 def test_dry_run(resource):


### PR DESCRIPTION
Follow-up to #94: An invalid timestamp format should not stop the resource from being downscaled.