### PR TITLE
Add ability to downscale HPA's minReplicas

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,9 +18,9 @@ Kubernetes Downscaler
    :target: http://calver.org/
    :alt: CalVer
 
-Scale down Kubernetes deployments and/or statefulsets during non-work hours.
+Scale down Kubernetes deployments and/or statefulsets and/or horizontalpodautoscalers during non-work hours.
 
-Deployments are interchangeable by statefulset for this whole guide.
+Deployments are interchangeable by statefulset/horizontalpodautoscalers for this whole guide unless explicitly stated otherwise.
 
 It will scale down the deployment's replicas if all of the following conditions are met:
 
@@ -39,6 +39,7 @@ It will scale down the deployment's replicas if all of the following conditions 
 * there are no active pods that force the whole cluster into uptime (annotation ``downscaler/force-uptime: "true"``)
 
 The deployment by default will be scaled down to zero replicas. This can be configured with a deployment or its namespace's annotation of ``downscaler/downtime-replicas`` (e.g. ``downscaler/downtime-replicas: "1"``) or via CLI with ``--downtime-replicas``.
+In case of horizontalpodautoscalers, the `minReplicas` field cannot be set to zero and thus ``downscaler/downtime-replicas`` should be atleast ``1``.
 
 Example use cases:
 
@@ -81,6 +82,10 @@ The downscaler will eventually log something like:
 
     INFO: Scaling down Deployment default/nginx from 1 to 0 replicas (uptime: Mon-Fri 09:00-17:00 America/Buenos_Aires, downtime: never)
 
+Note that in cases where HPA is used along with Deployments, consider the following:
+
+* If downscale to 0 is desired, annotation is applied at Deployment. (Special case, since minReplicas of 0 at HPA is not allowed. Setting Deployment replica to 0, essentially makes the HPA behave as disabled. In such a case, the HPA will emit events like `` failed to get memory utilization: unable to get metrics for resource memory: no metrics returned from resource metrics API`` as there is no Pod to retrieve metric from.)
+* If downscale greater than 0 is desired, annotation is applied at HPA. This allows for dynamic scaling of the Pods even during downtime based upon the external traffic as well as maintain a lower minReplicas during downtime if there is no/low traffic. If the Deployment is annotated instead of the HPA, it leads to a race condition where kube-downscaler downscales the Deployment and HPA upscales it as its minReplica is higher.
 
 Configuration
 =============
@@ -134,7 +139,7 @@ Available command line options:
 ``--namespace``
     Restrict the downscaler to work only in a single namespace (default: all namespaces). This is mainly useful for deployment scenarios where the deployer of kube-downscaler only has access to a given namespace (instead of cluster access).
 ``--include-resources``
-    Downscale resources of this kind as comma separated list. [deployments, statefulsets, stacks] (default: deployments)
+    Downscale resources of this kind as comma separated list. [deployments, statefulsets, stacks, horizontalpodautoscalers] (default: deployments)
 ``--grace-period``
     Grace period in seconds for new deployments before scaling them down (default: 15min). The grace period counts from time of creation of the deployment, i.e. updated deployments will immediately be scaled down regardless of the grace period.
 ``--upscale-period``

--- a/helm-chart/templates/clusterrole.yaml
+++ b/helm-chart/templates/clusterrole.yaml
@@ -31,6 +31,16 @@ rules:
   - update
   - patch
 - apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch
+- apiGroups:
   - ""
   resources:
   - namespaces

--- a/kube_downscaler/cmd.py
+++ b/kube_downscaler/cmd.py
@@ -38,7 +38,8 @@ def get_parser():
         "--include-resources",
         type=check_include_resources,
         default="deployments",
-        help="Downscale resources of this kind as comma separated list. [deployments, statefulsets, stacks, horizontalpodautoscalers] (default: deployments)",
+        help="Downscale resources of this kind as comma separated list. [%s] (default: deployments)"
+        % (",".join(VALID_RESOURCES)),
     )
     parser.add_argument(
         "--grace-period",

--- a/kube_downscaler/cmd.py
+++ b/kube_downscaler/cmd.py
@@ -1,7 +1,9 @@
 import argparse
 import os
 
-VALID_RESOURCES = frozenset(["deployments", "statefulsets", "stacks", "cronjobs"])
+VALID_RESOURCES = frozenset(
+    ["deployments", "statefulsets", "stacks", "cronjobs", "horizontalpodautoscalers"]
+)
 
 
 def check_include_resources(value):
@@ -36,7 +38,7 @@ def get_parser():
         "--include-resources",
         type=check_include_resources,
         default="deployments",
-        help="Downscale resources of this kind as comma separated list. [deployments, statefulsets, stacks] (default: deployments)",
+        help="Downscale resources of this kind as comma separated list. [deployments, statefulsets, stacks, horizontalpodautoscalers] (default: deployments)",
     )
     parser.add_argument(
         "--grace-period",


### PR DESCRIPTION
Addresses #69

Based on the downtime annotations on HPA, the minReplicas of the HPA are adjusted. When the annotations of the HPA and deployment are synced, it avoid the problem mentioned in https://github.com/hjacobs/kube-downscaler/issues/69#issuecomment-610194085
