### PR TITLE
script to recover from a bug

### DIFF
--- a/restore-cronjobs-starting-deadline-seconds.py
+++ b/restore-cronjobs-starting-deadline-seconds.py
@@ -19,7 +19,7 @@ for cronjob in CronJob.objects(api).filter(namespace=pykube.all):
         if last_applied_config_json:
             last_applied_config = json.loads(last_applied_config_json)
             original_value = last_applied_config["spec"].get("startingDeadlineSeconds")
-            if original_value is not None and original_value != 0:
+            if original_value is None or original_value != 0:
                 cronjob.obj["spec"]["startingDeadlineSeconds"] = original_value
                 print(
                     f"Updating startingDeadlineSeconds for {cronjob.namespace}/{cronjob.name} to {original_value}.."

--- a/restore-cronjobs-starting-deadline-seconds.py
+++ b/restore-cronjobs-starting-deadline-seconds.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Restore the startingDeadlineSeconds value from last-applied-configuration for all CronJobs."""
+import argparse
+import json
+
+import pykube
+from pykube import CronJob
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--dry-run", action="store_true")
+args = parser.parse_args()
+
+api = pykube.HTTPClient(pykube.KubeConfig.from_env())
+for cronjob in CronJob.objects(api).filter(namespace=pykube.all):
+    if cronjob.obj["spec"].get("startingDeadlineSeconds") == 0:
+        last_applied_config_json = cronjob.annotations.get(
+            "kubectl.kubernetes.io/last-applied-configuration"
+        )
+        if last_applied_config_json:
+            last_applied_config = json.loads(last_applied_config_json)
+            original_value = last_applied_config["spec"].get("startingDeadlineSeconds")
+            if original_value is not None and original_value != 0:
+                cronjob.obj["spec"]["startingDeadlineSeconds"] = original_value
+                print(
+                    f"Updating startingDeadlineSeconds for {cronjob.namespace}/{cronjob.name} to {original_value}.."
+                )
+                if not args.dry_run:
+                    cronjob.update()
+                else:
+                    print("** DRY-RUN **")


### PR DESCRIPTION
Kubernetes Downscaler currently breaks CronJobs because the `startingDeadlineSeconds` are set to zero and the value is never restored (#100).

This script helps to recover from this situation.