### PR TITLE
Show correct error message when multiple time specs are given

### DIFF
--- a/kube_downscaler/helper.py
+++ b/kube_downscaler/helper.py
@@ -33,8 +33,7 @@ def matches_time_spec(time: datetime.datetime, spec: str):
             return True
         if not recurring_match and not absolute_match:
             raise ValueError(
-                f'Time spec value "{spec}" does not match format ("Mon-Fri 06:30-20:30 Europe/Berlin" or'
-                + '"2019-01-01T00:00:00+00:00-2019-01-02T12:34:56+00:00")'
+                f'Time spec value "{spec_}" does not match format ("Mon-Fri 06:30-20:30 Europe/Berlin" or "2019-01-01T00:00:00+00:00-2019-01-02T12:34:56+00:00")'
             )
     return False
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -49,6 +49,19 @@ def test_time_spec():
     )
 
 
+def test_time_spec_error_message():
+    """Test that the correct error message is shown to the user."""
+    dt = datetime(2020, 4, 10, 10, 11, tzinfo=timezone.utc)
+    with pytest.raises(ValueError) as excinfo:
+        matches_time_spec(
+            dt, "Mon-Thur 09:00-20:00 Europe/London,Fri-Fri 10:00-18:00 Europe/London"
+        )
+    assert (
+        'Time spec value "Mon-Thur 09:00-20:00 Europe/London" does not match format ("Mon-Fri 06:30-20:30 Europe/Berlin" or "2019-01-01T00:00:00+00:00-2019-01-02T12:34:56+00:00")'
+        in str(excinfo.value)
+    )
+
+
 def test_week_starts_sunday():
     # Monday, November 27th 2017
     dt = datetime(2017, 11, 27, 15, 33, tzinfo=timezone.utc)


### PR DESCRIPTION
Fixes #101: fix the misleading error message and show the error for the individual time spec instead of the whole string.