### PR TITLE
Exclude namespaces with regex

### DIFF
--- a/kube_downscaler/cmd.py
+++ b/kube_downscaler/cmd.py
@@ -68,8 +68,8 @@ def get_parser():
     )
     parser.add_argument(
         "--exclude-namespaces",
-        help="Exclude namespaces from downscaling (default: kube-system)",
-        default=os.getenv("EXCLUDE_NAMESPACES", "kube-system"),
+        help="Exclude namespaces from downscaling (default: ^kube-system$)",
+        default=os.getenv("EXCLUDE_NAMESPACES", "^kube-system$"),
     )
     parser.add_argument(
         "--exclude-deployments",

--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -1,6 +1,8 @@
 import collections
 import datetime
 import logging
+import re
+
 from typing import FrozenSet
 from typing import Optional
 
@@ -342,9 +344,9 @@ def autoscale_resources(
 
     for current_namespace, resources in sorted(resources_by_namespace.items()):
 
-        if current_namespace in exclude_namespaces:
+        if any([re.match(i, current_namespace) for i in exclude_namespaces]):
             logger.debug(
-                f"Namespace {current_namespace} was excluded (exclusion list matches)"
+                f"Namespace {current_namespace} was excluded (exclusion list regex matches)"
             )
             continue
 


### PR DESCRIPTION
We have implemented a way to exclude namespaces via regex.
It is useful to exclude a group of namespaces without specify each namespace.
