### PR TITLE
Fix force uptime on namespace

### DIFF
--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -375,8 +375,11 @@ def autoscale_resources(
         downscale_period_for_namespace = namespace_obj.annotations.get(
             DOWNSCALE_PERIOD_ANNOTATION, downscale_period
         )
-        forced_uptime_for_namespace = namespace_obj.annotations.get(
-            FORCE_UPTIME_ANNOTATION, forced_uptime
+        forced_uptime_for_namespace = (
+            str(
+                namespace_obj.annotations.get(FORCE_UPTIME_ANNOTATION, forced_uptime)
+            ).lower()
+            == "true"
         )
         for resource in resources:
             autoscale_resource(

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -985,3 +985,66 @@ def test_scaler_name_excluded(monkeypatch):
     }
     assert api.patch.call_args[1]["url"] == "/deployments/deploy-2"
     assert json.loads(api.patch.call_args[1]["data"]) == patch_data
+
+
+def test_scaler_namespace_force_uptime_false(monkeypatch):
+    api = MagicMock()
+    monkeypatch.setattr(
+        "kube_downscaler.scaler.helper.get_kube_api", MagicMock(return_value=api)
+    )
+
+    def get(url, version, **kwargs):
+        if url == "pods":
+            data = {"items": []}
+        elif url == "deployments":
+            data = {
+                "items": [
+                    {
+                        "metadata": {
+                            "name": "deploy-1",
+                            "namespace": "ns-1",
+                            "creationTimestamp": "2019-03-01T16:38:00Z",
+                        },
+                        "spec": {"replicas": 1},
+                    },
+                ]
+            }
+        elif url == "namespaces/ns-1":
+            data = {"metadata": {"annotations": {"downscaler/force-uptime": "false"}}}
+        else:
+            raise Exception(f"unexpected call: {url}, {version}, {kwargs}")
+
+        response = MagicMock()
+        response.json.return_value = data
+        return response
+
+    api.get = get
+
+    include_resources = frozenset(["deployments"])
+    scale(
+        namespace=None,
+        upscale_period="never",
+        downscale_period="never",
+        default_uptime="never",
+        default_downtime="always",
+        include_resources=include_resources,
+        exclude_namespaces=[],
+        exclude_deployments=[],
+        dry_run=False,
+        grace_period=300,
+    )
+
+    assert api.patch.call_count == 1
+
+    # make sure that deploy-1 was updated
+    patch_data = {
+        "metadata": {
+            "name": "deploy-1",
+            "namespace": "default",
+            "creationTimestamp": "2019-03-01T16:38:00Z",
+            "annotations": {ORIGINAL_REPLICAS_ANNOTATION: "1"},
+        },
+        "spec": {"replicas": 0},
+    }
+    assert api.patch.call_args[1]["url"] == "/deployments/deploy-1"
+    assert json.loads(api.patch.call_args[1]["data"]) == patch_data


### PR DESCRIPTION
Only force uptime if the `downscaler/force-uptime` annotation on a namespace has the value `true`.

Fixes #109.