### PR TITLE
Allow force-uptime on namespace to accept periods

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -194,7 +194,7 @@ The following annotations are supported on the Namespace level:
 * ``downscaler/downscale-period``
 * ``downscaler/uptime``: set "uptime" for all resources in this namespace
 * ``downscaler/downtime``: set "downtime" for all resources in this namespace
-* ``downscaler/force-uptime``: force scaling up all resources in this namespace
+* ``downscaler/force-uptime``: force scaling up all resources in this namespace - can be ``true``/``false`` or a period
 * ``downscaler/exclude``: set to ``true`` to exclude all resources in the namespace
 * ``downscaler/exclude-until``: temporarily exclude all resources in the namespace until the given timestamp
 * ``downscaler/downtime-replicas``: overwrite the default target replicas to scale down to (default: zero)

--- a/kube_downscaler/scaler.py
+++ b/kube_downscaler/scaler.py
@@ -374,12 +374,20 @@ def autoscale_resources(
         downscale_period_for_namespace = namespace_obj.annotations.get(
             DOWNSCALE_PERIOD_ANNOTATION, downscale_period
         )
-        forced_uptime_for_namespace = (
-            str(
-                namespace_obj.annotations.get(FORCE_UPTIME_ANNOTATION, forced_uptime)
-            ).lower()
-            == "true"
+        forced_uptime_value_for_namespace = str(
+            namespace_obj.annotations.get(FORCE_UPTIME_ANNOTATION, forced_uptime)
         )
+        if forced_uptime_value_for_namespace.lower() == "true":
+            forced_uptime_for_namespace = True
+        elif forced_uptime_value_for_namespace.lower() == "false":
+            forced_uptime_for_namespace = False
+        elif forced_uptime_value_for_namespace:
+            forced_uptime_for_namespace = matches_time_spec(
+                now, forced_uptime_value_for_namespace
+            )
+        else:
+            forced_uptime_for_namespace = False
+
         for resource in resources:
             autoscale_resource(
                 resource,

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -1098,3 +1098,113 @@ def test_scaler_namespace_force_uptime_false(monkeypatch):
     }
     assert api.patch.call_args[1]["url"] == "/deployments/deploy-1"
     assert json.loads(api.patch.call_args[1]["data"]) == patch_data
+
+
+def test_scaler_namespace_force_uptime_period(monkeypatch):
+    api = MagicMock()
+    monkeypatch.setattr(
+        "kube_downscaler.scaler.helper.get_kube_api", MagicMock(return_value=api)
+    )
+    ORIGINAL_REPLICAS = 2
+
+    def get(url, version, **kwargs):
+        if url == "pods":
+            data = {"items": []}
+        elif url == "deployments":
+            data = {
+                "items": [
+                    {
+                        "metadata": {
+                            "name": "deploy-1",
+                            "namespace": "ns-1",
+                            "creationTimestamp": "2019-03-01T16:38:00Z",
+                            "annotations": {
+                                ORIGINAL_REPLICAS_ANNOTATION: ORIGINAL_REPLICAS,
+                            },
+                        },
+                        "spec": {"replicas": 0},
+                    },
+                    {
+                        "metadata": {
+                            "name": "deploy-2",
+                            "namespace": "ns-2",
+                            "creationTimestamp": "2019-03-01T16:38:00Z",
+                            "annotations": {
+                                ORIGINAL_REPLICAS_ANNOTATION: ORIGINAL_REPLICAS,
+                            },
+                        },
+                        "spec": {"replicas": 0},
+                    },
+                    {
+                        "metadata": {
+                            "name": "deploy-3",
+                            "namespace": "ns-3",
+                            "creationTimestamp": "2019-03-01T16:38:00Z",
+                            "annotations": {
+                                ORIGINAL_REPLICAS_ANNOTATION: ORIGINAL_REPLICAS,
+                            },
+                        },
+                        "spec": {"replicas": 0},
+                    },
+                ]
+            }
+        elif url == "namespaces/ns-1":
+            # past period
+            data = {
+                "metadata": {
+                    "annotations": {
+                        "downscaler/force-uptime": "2020-04-04T16:00:00+00:00-2020-04-05T16:00:00+00:00"
+                    }
+                }
+            }
+        elif url == "namespaces/ns-2":
+            # current period
+            data = {
+                "metadata": {
+                    "annotations": {
+                        "downscaler/force-uptime": "2020-04-04T16:00:00+00:00-2040-04-05T16:00:00+00:00"
+                    }
+                }
+            }
+        elif url == "namespaces/ns-3":
+            # future period
+            data = {
+                "metadata": {
+                    "annotations": {
+                        "downscaler/force-uptime": "2040-04-04T16:00:00+00:00-2040-04-05T16:00:00+00:00"
+                    }
+                }
+            }
+        else:
+            raise Exception(f"unexpected call: {url}, {version}, {kwargs}")
+
+        response = MagicMock()
+        response.json.return_value = data
+        return response
+
+    api.get = get
+
+    include_resources = frozenset(["deployments"])
+    scale(
+        namespace=None,
+        upscale_period="never",
+        downscale_period="never",
+        default_uptime="never",
+        default_downtime="always",
+        include_resources=include_resources,
+        exclude_namespaces=[],
+        exclude_deployments=[],
+        dry_run=False,
+        grace_period=300,
+    )
+
+    # make sure that deploy-2 was updated
+    assert api.patch.call_count == 1
+    assert api.patch.call_args[1]["url"] == "/deployments/deploy-2"
+    assert (
+        json.loads(api.patch.call_args[1]["data"])["spec"]["replicas"]
+        == ORIGINAL_REPLICAS
+    )
+    assert not json.loads(api.patch.call_args[1]["data"])["metadata"]["annotations"][
+        ORIGINAL_REPLICAS_ANNOTATION
+    ]


### PR DESCRIPTION
This PR adds the possibility to use a period when using force-uptime annotation on a namespace.

Example usage:
  downscaler/force-uptime: 2020-05-02T08:00:00+02:00-2020-05-02T08:30:00+02:00

The annotation still accepts "true" or "false" value, so this is mostly backward compatible, except if people were using `downscaler/force-uptime: foo` to disable force-uptime, in which case it will now fail complaining that `foo` is not a valid period.

## Use case

This option allows to book an uptime for a namespace, to make sure that whatever the default config is, it will be up during that period. Besides this forced period, the default behaviour will be applied.

## Alternative 

Currently, when you want to force a namespace to be up you can use exclude-until, but it makes the namespace up until the date, so you can't book a slot in the future, it will keep the namespace up until the end of exclusion.

Another way to force a namespace up is to override the uptime value, but int this case the default value will be ignored, so you have to remember to remove your namespace specific annotation after the booking, otherwise if you change the default values it won't be taken into account for that namespace.

## Design

Reusing the force-uptime annotation for that purpose seemed to be the easiest both to implement and to use. If you think it would be better to introduce a new annotation I can review the PR

## Implementation

This is my first time with python, I wrote a unit test and tried to follow the coding style but feel free to comment if there's something wrong in my approach.

I've also updated the README with a very basic on comment on that new option, let me know if you would like more extensive documentation.